### PR TITLE
Updating Projects page and Events

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -61,7 +61,6 @@
     <div class="pure-g footer bg-darkest">
 
         <h5 class="center white">Created with <font color="C67171">&#60;3</font> by <a href="https://github.com/venegu" target="Lisa" class="salmon">Lisa Maldonado</a> and <a href="https://github.com/DrkSephy" target="David" class="black">David Leonard</a> for the CCNY ACM</h5>
-
     </div>
 
     <!-- This is generated using Professor Skeith's antispam fun thing that can be found here: https://web.archive.org/web/20080416142658/http://www.binaryskeith.com/antiSpam.html -->

--- a/css/main.css
+++ b/css/main.css
@@ -19,6 +19,11 @@ li {
     list-style: none;
     padding-bottom: 1.0em;
 }
+
+.no_bottom_pad {
+    padding-bottom: 0em;
+}
+
 ul {
     list-style: none;
 }
@@ -180,6 +185,7 @@ ul {
 .card-header a {
     color:white;
 }
+
 
 /*************
     Footer

--- a/events.html
+++ b/events.html
@@ -43,28 +43,28 @@
         <div class="pure-u-1 pure-u-md-1-3 center">
             <div class="round">
                 <h2>GameDev</h2>
-                <h3><b>Friday, October 9th</b></h3>
-                <h3>4:00 P.M. - 6:00 P.M.</h3>
-                <h3>NAC 1/211</h3>
-
-            </div>
-        </div>
-
-        <div class="pure-u-1 pure-u-md-1-3 center">
-            <div class="round">
-                <h2>Git Workshop</h2>
-                <h3><b>Thursday, October 8th</b></h3>
+                <h3><b>Tuesday, October 13th</b></h3>
                 <h3>12:30 P.M. - 1:45 P.M.</h3>
-                <h3>NAC 1/209</h3>
+                <h3><b>NAC 7/227</b></h3>
+
             </div>
         </div>
 
         <div class="pure-u-1 pure-u-md-1-3 center">
             <div class="round">
                 <h2>GameDev</h2>
-                <h3><b>Tuesday, October 13th</b></h3>
+                <h3><b>Friday, October 16th</b></h3>
+                <h3>4:00 P.M. - 6:00 P.M.</h3>
+                <h3><b>NAC 1/211</b></h3>
+            </div>
+        </div>
+
+        <div class="pure-u-1 pure-u-md-1-3 center">
+            <div class="round">
+                <h2>GameDev</h2>
+                <h3><b>Tuesday, October 20th</b></h3>
                 <h3>12:30 P.M. - 1:45 P.M.</h3>
-                <h3>NAC 7/227</h3>
+                <h3><b>NAC 7/227</b></h3>
             </div>
         </div>
     </div> <!-- Event Cards end -->
@@ -125,8 +125,8 @@
             </div> <!-- cd-timeline-img -->
 
             <div class="cd-timeline-content">
-                <h2><b>Git Workshop</b></h2>
-                <h3><b>Thursday, October 8th</b></h3>
+                <h2>Git Workshop</h2>
+                <h3>Thursday, October 8th</h3>
                 <h3>12:30 P.M. - 1:45 P.M.</h3>
                 <h3>NAC 1/209</h3>
                 <p>Join us in learning Git and Github! Git is considered a lifeline for programmers academically and in the industry. If you are participating in <b>GameDev</b> this might be helpful!</p>
@@ -140,8 +140,8 @@
                 <!--<img src="media/cd-icon-location.svg" alt="Location">-->
             </div> <!-- cd-timeline-img -->
             <div class="cd-timeline-content">
-                <h2><b>GameDev</b></h2>
-                <h3><b>Friday, October 9th</b></h3>
+                <h2>GameDev</h2>
+                <h3>Friday, October 9th</h3>
                 <h3>4:00 P.M. - 6:00 P.M.</h3>
                 <h3>NAC 1/211</h3>
                 <p>GameDev teams will have the space to meet and work on creating games!</p>

--- a/projects.html
+++ b/projects.html
@@ -36,7 +36,10 @@
         <div class="pure-u-1">
         <h1 class="center">Current Projects</h1>
         <div class="round-2">
-            <p>GameDev will not start until October 2nd. Check back then :)!</p>
+            <li>Unity Team</li>
+            <li>Android Team 1</li>
+            <li>Pokemon RPG game</li>
+            <li></li>
         </div>
         </div>
     </div>

--- a/projects.html
+++ b/projects.html
@@ -36,10 +36,15 @@
         <div class="pure-u-1">
         <h1 class="center">Current Projects</h1>
         <div class="round-2">
+        <p>
             <li>Unity Team</li>
             <li>Android Team 1</li>
-            <li>Pokemon RPG game</li>
-            <li></li>
+            <li>Android Team 2</li>
+            <li>Pokemon RPG</li>
+            <li>Phaser Team</li>
+            <li>Popsquad Pokemon Team</li>
+            <li class="no_bottom_pad">Pokemon Emerald Team</li>
+        </p>
         </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request adds the list of current GameDev teams to the *Current Projects* section (to be updated into actual project when more progress has been made). Additionally, events that already passed were replaced with upcoming events in the cards section and the timeline events that already occurred were unbolded in the events page. (I wonder if there is a smarter way to do this on a static website). :mask: 